### PR TITLE
Revert "Bump bumpalo from 3.8.0 to 3.12.0 in /packages/server/src/auth/message_signing/rust"

### DIFF
--- a/packages/server/src/auth/message_signing/rust/Cargo.lock
+++ b/packages/server/src/auth/message_signing/rust/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
Reverts Vrooli/Vrooli#147