### PR TITLE
Fix code scanning alert no. 50: Use of externally-controlled format string

### DIFF
--- a/packages/ui/src/utils/localStorage.ts
+++ b/packages/ui/src/utils/localStorage.ts
@@ -236,7 +236,7 @@ export class LocalStorageLruCache<ValueType> {
                 return JSON.parse(serializedValue);
             }
         } catch (error) {
-            console.error(`Error parsing value for key ${key} from localStorage:`, error);
+            console.error("Error parsing value for key %s from localStorage:", key, error);
         }
         return undefined;
     }

--- a/packages/ui/src/utils/localStorage.ts
+++ b/packages/ui/src/utils/localStorage.ts
@@ -236,7 +236,7 @@ export class LocalStorageLruCache<ValueType> {
                 return JSON.parse(serializedValue);
             }
         } catch (error) {
-            console.error("Error parsing value for key %s from localStorage:", key, error);
+            console.error("Error parsing value from localStorage", key, error);
         }
         return undefined;
     }


### PR DESCRIPTION
Fixes [https://github.com/Vrooli/Vrooli/security/code-scanning/50](https://github.com/Vrooli/Vrooli/security/code-scanning/50)

To fix the problem, we should ensure that the `key` is safely included in the error message by using a format specifier (`%s`) and passing the `key` as an argument to `console.error`. This approach prevents any format string vulnerabilities by treating the `key` as a plain string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
