### PR TITLE
Fix code scanning alert no. 49: Unvalidated dynamic method call

### DIFF
--- a/packages/shared/src/utils/runUtils.ts
+++ b/packages/shared/src/utils/runUtils.ts
@@ -2137,7 +2137,9 @@ export function parseSchemaOutput(
     logger: PassableLogger,
 ): FormSchema {
     return parseSchema(value, () => {
-        if (!routineType) return defaultSchemaOutput();
+        if (!routineType || typeof defaultConfigFormOutputMap[routineType] !== 'function') {
+            return defaultSchemaOutput();
+        }
         return defaultConfigFormOutputMap[routineType]();
     }, logger, "output");
 }


### PR DESCRIPTION
Fixes [https://github.com/Vrooli/Vrooli/security/code-scanning/49](https://github.com/Vrooli/Vrooli/security/code-scanning/49)

To fix the problem, we need to ensure that the `routineType` is a valid key in the `defaultConfigFormOutputMap` object before attempting to call the corresponding function. This can be achieved by checking if `routineType` exists in the `defaultConfigFormOutputMap` and if the value is a function. If the check fails, we should fall back to a default function.

1. Modify the `parseSchemaOutput` function to include a validation check for `routineType`.
2. Ensure that the function retrieved from `defaultConfigFormOutputMap` is indeed a function before calling it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
