### PR TITLE
Fix code scanning alert no. 49: Unvalidated dynamic method call

### DIFF
--- a/packages/shared/src/utils/runUtils.ts
+++ b/packages/shared/src/utils/runUtils.ts
@@ -2137,7 +2137,7 @@ export function parseSchemaOutput(
     logger: PassableLogger,
 ): FormSchema {
     return parseSchema(value, () => {
-        if (!routineType || typeof defaultConfigFormOutputMap[routineType] !== 'function') {
+        if (!routineType || !defaultConfigFormOutputMap.hasOwnProperty(routineType) || typeof defaultConfigFormOutputMap[routineType] !== 'function') {
             return defaultSchemaOutput();
         }
         return defaultConfigFormOutputMap[routineType]();


### PR DESCRIPTION
Fixes [https://github.com/Vrooli/Vrooli/security/code-scanning/49](https://github.com/Vrooli/Vrooli/security/code-scanning/49)

To fix the problem, we need to ensure that the `routineType` is a valid key in the `defaultConfigFormOutputMap` object and that the corresponding value is a function before invoking it. This can be achieved by adding a validation check using `hasOwnProperty` and `typeof` to ensure the method exists and is callable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
