### PR TITLE
Fix code scanning alert no. 48: Unvalidated dynamic method call

### DIFF
--- a/packages/shared/src/utils/runUtils.ts
+++ b/packages/shared/src/utils/runUtils.ts
@@ -2126,7 +2126,9 @@ export function parseSchemaInput(
     logger: PassableLogger,
 ): FormSchema {
     return parseSchema(value, () => {
-        if (!routineType) return defaultSchemaInput();
+        if (!routineType || !defaultConfigFormInputMap.hasOwnProperty(routineType) || typeof defaultConfigFormInputMap[routineType] !== 'function') {
+            return defaultSchemaInput();
+        }
         return defaultConfigFormInputMap[routineType]();
     }, logger, "input");
 }


### PR DESCRIPTION
Fixes [https://github.com/Vrooli/Vrooli/security/code-scanning/48](https://github.com/Vrooli/Vrooli/security/code-scanning/48)

To fix the problem, we need to validate that the `routineType` is a valid key in the `defaultConfigFormInputMap` object and that the value retrieved is a function before invoking it. This can be achieved by adding a check using `hasOwnProperty` and `typeof` to ensure the key exists and the value is a function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
