### PR TITLE
Fix setup internet check behavior

### DIFF
--- a/docs/scratch/network_issue_research.md
+++ b/docs/scratch/network_issue_research.md
@@ -1,0 +1,11 @@
+## Notes on 'Host internet access to google.com: FAILED' issue
+
+- `internet.sh` checks connectivity via `ping` to `google.com`.
+- In the Codex environment, `ping` fails with 'Network is unreachable' while HTTP requests succeed.
+- Web search results show others have had similar issues:
+  - StackOverflow: "Not able to connect to network inside docker container".
+  - Docker Community Forums: "Docker error network is unreachable".
+  - AskUbuntu: "No network access from within docker container".
+- These indicate that ICMP (ping) may be blocked in some container environments, though HTTP works.
+- The setup script was updated to log the ping failure and continue instead of exiting.
+

--- a/scripts/helpers/setup/internet.bats
+++ b/scripts/helpers/setup/internet.bats
@@ -17,9 +17,9 @@ SCRIPT_PATH="$BATS_TEST_DIRNAME/internet.sh"
     [[ "$output" =~ \[SUCCESS\]\ +Host\ internet\ access:\ OK ]]
 }
 
-@test "internet::check_connection prints error and exits with correct code when ping fails" {
+@test "internet::check_connection logs error but continues when ping fails" {
     run bash -c "export ERROR_NO_INTERNET=5; source '$SCRIPT_PATH'; ping(){ return 1; }; internet::check_connection"
-    [ "$status" -eq 5 ]
+    [ "$status" -eq 0 ]
     [[ "$output" =~ \[HEADER\]\ +Checking\ host\ internet\ access\.\.\. ]]
     [[ "$output" =~ \[ERROR\]\ +Host\ internet\ access:\ FAILED ]]
 }

--- a/scripts/helpers/setup/internet.sh
+++ b/scripts/helpers/setup/internet.sh
@@ -63,7 +63,8 @@ internet::check_connection() {
         log::success "Host internet access to $host: OK"
     else
         log::error "Host internet access to $host: FAILED"
-        exit "${ERROR_NO_INTERNET}"
+        # Continue without exiting so setup doesn't halt in restricted environments
+        return 0
     fi
 }
 


### PR DESCRIPTION
## Summary
- keep internet check from halting setup
- adjust tests to reflect new behavior
- note ping failure handling in scratch notes

## Testing
- `bash scripts/main/setup.sh` *(fails later due to apt-get upgrade)*
- `pnpm -r run lint` *(fails: ESLint couldn't find configuration)*
- `pnpm -r run test` *(fails: run-s / vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840974d24e88330bb02069f967d348c